### PR TITLE
Render Link correctly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or install it yourself as:
 
 ## Contributing
 
-1. Fork it ( http://github.com/<my-github-username>/git_merge_pr/fork )
+1. [Fork it](https://github.com/parkr/git-merge-pr/fork)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)


### PR DESCRIPTION
Currently renders as 

> Fork it ( [http://github.com/](http://github.com/)/git_merge_pr/fork )

closes #7.
